### PR TITLE
Update specification.rst

### DIFF
--- a/docs/specification.rst
+++ b/docs/specification.rst
@@ -71,13 +71,14 @@ rules:
    recognized acronyms, e.g., ``DC``, ``RF``, ``PRT``, ``CMM``.
    [AcronymRule]
 
-#. Parameters substitute for additional tokens to distinguish details
-   within the same measurement process. [ParameterRule]
-   ``Source.Temperature.Simulated.Thermocouple``, for example, covers
-   all thermocouple types via a type parameter, whereas a separate taxon
-   (``Source.Temperature.Simulated.PRT``) covers platinum resistance
-   thermometers (PRTs) because the measurement process changes (sourcing
-   resistance instead of voltage).
+#. Add tokens only when required to distinguish measurands with 
+   different parameter sets.For simulated temperature sources, for 
+   example, (``Source.Temperature.Simulated``) we add ``.Thermocouple`` 
+   or ``.PRT`` to distinguish thermocouple parameters (temperature, 
+   voltage, type) from PRT parameters (temperature, resistance, type). 
+   We do not add a token for thermocouple types because we may use a 
+   key-value parameter (e.g., 'ThermocoupleType'='T') and all types 
+   then use the same parameter set.
 
 #. Special tokens with their own syntax identify common measurement
    scenarios. [SpecialTokenRule]


### PR DESCRIPTION
Replaced taxonomy Rule 10, which appears to violate our intention to decouple the taxon name from the measurement process. It also leaves some situations unclear as to whether to use a parameter or add a token.

The optimal differentiation probably requires some fundamental modeling thought to definitively answer.

Potential differentiating criteria in the meantime: Likelihood of additional parameter values in the future--maybe Parameters for numeric input and influence quantity values only--no Required-parameter set--yes, drafted accordingly

We should examine examples to break, refine or support this rule.

I didn't restore the  [ParameterRule]  label but it appears the rst file lacks some label work throughout.