### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-@NCSLI-MII/committer-taxonomy
+* @NCSLI-MII/committer-taxonomy


### PR DESCRIPTION
Missing wildcard to designate all files in repo for codeowners @NCSLI-MII/committer-taxonomy 