### PR TITLE
Maintenance scripts

### DIFF
--- a/scripts/combiner.sh
+++ b/scripts/combiner.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+#
+# Copyright © 2023 by NCSL International. All rights reserved
+# Copyright © 2025 Ryan Mackenzie White <ryan.white4@canada.ca>
+#
+# Distributed under terms of the Copyright © Her Majesty the Queen in Right of Canada, as represented by the Minister of Statistics Canada, 2019. license.
+# 
+# Given an input directory containing individual taxon files
+# the following merges the files and adds the required comments.
+# Requires python environment with xmltodict and yq installed
+
+dirlist=`ls -d "$1"/*xml`
+echo $dirlist
+#echo "${dirlist[@]}"
+
+xq -s '{Taxonomy: {Taxon: [.[].Taxon]}} | .Taxonomy += {"@xmlns:mtc":.Taxonomy.Taxon.[0]["@xmlns:mtc"]} | .Taxonomy += {"@xmlns:uom":.Taxonomy.Taxon.[0]["@xmlns:uom"]} | del(.Taxonomy.Taxon.[]["@xmlns:mtc"]) | del(.Taxonomy.Taxon.[]["@xmlns:uom"])' $dirlist -x | tee $1/merge.xml
+
+sed -i '1 i\\<\!\-\-\
+    \# Copyright\
+    \Copyright © 2023 by NCSL International. All rights reserved\
+    \# Permission To Reproduce\
+    \NCSL International (NCSLI) grants permission to make fair use of the material contained in this publication, including reproduction of part or all of its pages, according to the Creative Commons Attribution 4.0 license and under the following conditions\: \
+    \1) The NCSLI copyright notice appears at the beginning of the publication.\
+    \2) The words “NCSL International Technical Publication” appears on each page reproduced.\
+    \3) The disclaimer hereafter is incorporated and understood by all persons or organizations reproducing the publication.\
+    \# Permission To Translate\
+    \Permission to translate part or all of this publication is granted provided that the following conditions are met\:\
+    \1) The NCSLI copyright notice appears at the beginning of the translation.\
+    \2) The words “Translated by [translator\x27s name]” appear on each page translated.\
+    \3) The following disclaimer is included and understood by all persons or organizations translating this publication. If the translation is copyrighted, the translation must carry a copyright notice for both the translation and for the publication from which it is translated.\
+    \# Disclaimer\
+    \The materials and information contained herein are provided and promulgated as an industry aid and guide, and are based on standards, formulae, and techniques recognized by NCSL International. The materials are prepared without reference to any specific federal, state, or local laws or regulations, and NCSL International does not warrant or guarantee any specific result when relied upon. The materials provide a guide or recommended practices and are not all-inclusive.\
+    \From time-to-time commercial equipment, instruments, or materials are identified in technical publications to foster understanding. Such identification does not imply recommendation or endorsement by the NCSL International, nor does it imply that the materials or equipment identified are necessarily the best available for the purpose.\
+    \Non-binding CC license summary: https\:\/\/creativecommons.org\/licenses\/by-sa\/4.0\/\
+    \Legal license: https\:\/\/creativecommons.org\/licenses\/by-sa\/4.0\/legalcode\
+\-\-\>' $1/merge.xml
+
+sed -i '1 i\\<\?xml version="1.0" encoding="utf-8"\?\>' $1/merge.xml 
+sed -i 's/\<Taxon/\mtc:Taxon/g' $1/merge.xml
+echo $1
+
+
+

--- a/scripts/roundtrip.sh
+++ b/scripts/roundtrip.sh
@@ -1,0 +1,26 @@
+#! /bin/sh
+#
+# roundtrip.sh
+# Copyright © 2023 by NCSL International. All rights reserved
+# Copyright (C) 2025 Ryan Mackenzie White <ryan.white4@canada.ca>
+#
+# Distributed under terms of the Copyright © Her Majesty the Queen in Right of Canada, as represented by the Minister of Statistics Canada, 2019. license.
+#
+# Round trip script
+# Creates temporary output directory.
+# Splits the full catalog and writes individual files to temp dir.
+# Merges files back into catalog
+# Validates final output
+#
+
+tempdir=`mktemp -d`
+echo $tempdir
+`python scripts/splitter.py -v -d "$tempdir" > $tempdir/log.txt`
+grep INFO $tempdir/log.txt | while read line; do
+    echo $line
+done
+dirlist=`ls -d "$tempdir"/*`
+echo $dirlist
+sh scripts/combiner.sh $tempdir
+`python scripts/validator.py -v -d "$tempdir" -f merge.xml > $tempdir/validate.txt`
+

--- a/scripts/splitter.py
+++ b/scripts/splitter.py
@@ -1,0 +1,77 @@
+#! /usr/bin/env python3
+# vim:fenc=utf-8
+#
+# Copyright © 2023 by NCSL International. All rights reserved
+# Copyright © 2025 Ryan Mackenzie White <ryan.white4@canada.ca>
+#
+# Distributed under terms of the Copyright © Her Majesty the Queen in Right of Canada, as represented by the Minister of Statistics Canada, 2019. license.
+
+"""
+
+"""
+import tempfile
+import argparse 
+import pprint
+
+import xmltodict
+
+def main(*args):
+    infile = args[0]
+    dirpath = args[1]
+    verbose = args[2]
+    
+    print(f'INFO: Splitting Taxonomy filename {args[0]}')
+    print(f'INFO: Splitting Taxonomy to temporary path {dirpath}')
+    
+    schema_taxonomy = (
+            "https://cls-schemas.s3.us-west-1.amazonaws.com/MII/MeasurandTaxonomyCatalog"
+            )
+
+    schema_uom = (
+        "https://cls-schemas.s3.us-west-1.amazonaws.com/MII/UOM_Database"
+    )
+    
+    taxons ={}
+    with open(infile) as f:
+        taxons = xmltodict.parse(f.read())
+    
+    for taxon in taxons["mtc:Taxonomy"]["mtc:Taxon"]:
+
+        dict_ = {"Taxon":taxon}
+        dict_['Taxon']['@xmlns:mtc'] = schema_taxonomy
+        dict_['Taxon']['@xmlns:uom'] = schema_uom
+        fname =  dict_['Taxon']['@name'].replace('.', '_')+'.xml'
+        
+        if verbose is True:
+            print(f"=====================================================")
+            print(f"Writing dict_['Taxon']['@name'] to {dirpath}/{fname}")
+            pprint.pprint(taxon)
+            print(xmltodict.unparse(dict_, pretty=True)) 
+
+        with open(dirpath+'/'+fname, 'w') as f:
+            f.write(xmltodict.unparse(dict_, pretty=True))
+    return dirpath
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+            prog='splitter',
+            description='Generates individual taxon xml from complete catalog',
+            )
+    parser.add_argument('-f', '--filename', 
+            default='MeasurandTaxonomyCatalog.xml', 
+            help="Input taxonomy file")
+    parser.add_argument('-d', '--dirpath', help="Output directory")
+    parser.add_argument('-v', '--verbose', action='store_true')
+    args = parser.parse_args()
+    print(args)
+    print(f'INFO: filename args.filename')
+    print(f'INFO: verbose args.verbose')
+    print(f'INFO: output directory args.dirpath')
+
+    if args.dirpath:
+        dirpath = args.dirpath
+    else:
+        dirpath = tempfile.mkdtemp()
+
+    main(args.filename, dirpath, args.verbose)

--- a/scripts/validator.py
+++ b/scripts/validator.py
@@ -1,0 +1,40 @@
+#! /usr/bin/env python3
+# vim:fenc=utf-8
+#
+# Copyright © 2023 by NCSL International. All rights reserved
+# Copyright © 2025 Ryan Mackenzie White <ryan.white4@canada.ca>
+#
+# Distributed under terms of the Copyright © Her Majesty the Queen in Right of Canada, as represented by the Minister of Statistics Canada, 2019. license.
+
+"""
+Validation script for schema and catalog.
+Uses schema in current directory.
+Optional input taxonomy file can passed for validation.
+Requires python environment with xmlschema
+"""
+
+import xmlschema
+import argparse
+from pathlib import Path
+
+def validate(*args):
+    schema = xmlschema.XMLSchema('MeasurandTaxonomyCatalog.xsd')
+    schema.validate(args[0])
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+            prog='validator',
+            description='Validates taxonomy and schema'
+            )
+    parser.add_argument('-f', '--filename', 
+            default='MeasurandTaxonomyCatalog.xml', 
+            help="Input taxonomy file")
+    parser.add_argument('-d', '--dirpath', help="Output directory")
+    parser.add_argument('-v', '--verbose', action='store_true')
+    
+    args = parser.parse_args()
+    print(args)
+    p = Path(args.dirpath)
+    f = p / args.filename
+    print(f.resolve())
+    validate(f)


### PR DESCRIPTION
Pull request to add maintenance scripts to the repository. The command line scripts provide the following functionality:
- Ability to split the catalog to individual files written to a temporary directory
- Ability to combine individual files and write a valid xml catalog file
- Ability to run xml validation from cmdline
- Test script that round trips the above

Once merged this will allow further automation. Also provides a utility to bulk update the individual source taxon files from bulk change in the catalog (e.g. due to schema changes).

Note that requirements file needs to be updated so that dependencies can be installed. This will be done later.