### PR TITLE
136 taxon sourcemassflowrategas

### DIFF
--- a/source/Source_MassFlowRate_Gas.xml
+++ b/source/Source_MassFlowRate_Gas.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mtc:Taxon name="Source.MassFlowRate.Gas" deprecated="false" replacement="" xmlns:uom="https://cls-schemas.s3.us-west-1.amazonaws.com/MII/UOM_Database" xmlns:mtc="https://cls-schemas.s3.us-west-1.amazonaws.com/MII/MeasurandTaxonomyCatalog">
+	<mtc:Result name="MassFlowRate">
+		<mtc:mLayer aspect="as_mass_flow_rate" id="AS134"></mtc:mLayer>
+	</mtc:Result>
+	<mtc:Parameter name="MassFlowRate" optional="false">
+		<mtc:Definition>Mass of a substance passing through a specific cross-sectional area</mtc:Definition>
+		<mtc:mLayer aspect="as_mass_flow_rate" id="AS134"></mtc:mLayer>
+	</mtc:Parameter>
+	<mtc:Parameter name="Temperature" optional="true">
+		<mtc:Definition>Temperature of the gas used during the measurement</mtc:Definition>
+		<mtc:mLayer aspect="as_thermodynamic_temperature" id="AS101"></mtc:mLayer>
+	</mtc:Parameter>
+	<mtc:Parameter name="Pressure" optional="true">
+		<mtc:Definition>Pressure of the gas used during the measurement</mtc:Definition>
+		<mtc:mLayer aspect="as_pressure" id="AS14"></mtc:mLayer>
+	</mtc:Parameter>
+	<mtc:Parameter name="RelativeHumidity " optional="true">
+		<mtc:Definition>Relative humidity (water content) of the gas used during measurement, mostly applicable to ambient air as the medium</mtc:Definition>
+		<mtc:mLayer aspect="as_relative_humidity" id="AS110"></mtc:mLayer>
+	</mtc:Parameter>
+	<mtc:Parameter name="Compressibility" optional="true">
+		<mtc:Definition>Relative volume change as a result of a pressure change of the gas used</mtc:Definition>
+	</mtc:Parameter>
+	<mtc:Parameter name="ReferenceTemperature" optional="true">
+		<mtc:Definition> Reference temperature condition to or from which to correct the flow rate</mtc:Definition>
+		<mtc:mLayer aspect="as_thermodynamic_temperature" id="AS101"></mtc:mLayer>
+	</mtc:Parameter>
+	<mtc:Parameter name="ReferencePressure" optional="true">
+		<mtc:Definition>Reference pressure condition to or from which to correct the flow rate</mtc:Definition>
+		<mtc:mLayer aspect="as_pressure" id="AS14"></mtc:mLayer>
+	</mtc:Parameter>
+	<mtc:Parameter name="ReferenceRelativeHumidity" optional="true">
+		<mtc:Definition>Reference Relative Humidity: condition to or from which to correct the flow rate</mtc:Definition>
+		<mtc:mLayer aspect="as_relative_humidity" id="AS110"></mtc:mLayer>
+	</mtc:Parameter>
+	<mtc:Parameter name="ReferenceCompressibility" optional="true">
+		<mtc:Definition>Relative volume change as a result of a pressure change for the reference gas</mtc:Definition>
+	</mtc:Parameter>
+	<mtc:Parameter name="AmbientTemperature" optional="true">
+		<mtc:Definition></mtc:Definition>
+		<mtc:mLayer aspect="as_thermodynamic_temperature" id="AS101"></mtc:mLayer>
+	</mtc:Parameter>
+	<mtc:Parameter name="AmbientPressure" optional="true">
+		<mtc:Definition></mtc:Definition>
+		<mtc:mLayer aspect="as_pressure" id="AS14"></mtc:mLayer>
+	</mtc:Parameter>
+	<mtc:Parameter name="AmbientRelativeHumidity" optional="true">
+		<mtc:Definition></mtc:Definition>
+		<mtc:mLayer aspect="as_relative_humidity" id="AS110"></mtc:mLayer>
+	</mtc:Parameter>
+	<mtc:Parameter name="OutletPressure" optional="true">
+		<mtc:Definition>Outlet pressure ambient or otherwise</mtc:Definition>
+		<mtc:mLayer aspect="as_pressure" id="AS14"></mtc:mLayer>
+	</mtc:Parameter>
+	<mtc:Parameter name="ReynoldsNumber" optional="true">
+		<mtc:Definition>Dimensionless quantity that characterizes the degree of laminar versus turbulent flow</mtc:Definition>
+	</mtc:Parameter>
+	<mtc:Parameter name="GasVelocity" optional="true">
+		<mtc:Definition>speed of the gas through the measurement area</mtc:Definition>
+		<mtc:mLayer aspect="as_speed" id="AS38"></mtc:mLayer>
+	</mtc:Parameter>
+	<mtc:Parameter name="Diameter" optional="true">
+		<mtc:Definition>Diameter of the pipe used in the measurement</mtc:Definition>
+		<mtc:mLayer aspect="as_length" id="AS3"></mtc:mLayer>
+	</mtc:Parameter>
+	<mtc:Discipline name=""></mtc:Discipline>
+	<mtc:Definition>This process sources a reference mass flow rate of gas for calibrating gas-flow meters. The instantaneous mass flow rate q_m equals dm/dt, sometimes estimated as ∆m/∆t using the total mass ∆m flowing through a defined surface in time ∆t.</mtc:Definition>
+</mtc:Taxon>

--- a/source/Source_MassFlowRate_Gas.xml
+++ b/source/Source_MassFlowRate_Gas.xml
@@ -1,77 +1,77 @@
 <?xml version="1.0" encoding="utf-8"?>
 <mtc:Taxon name="Source.MassFlowRate.Gas" deprecated="false" replacement="" xmlns:uom="https://cls-schemas.s3.us-west-1.amazonaws.com/MII/UOM_Database" xmlns:mtc="https://cls-schemas.s3.us-west-1.amazonaws.com/MII/MeasurandTaxonomyCatalog">
 	<mtc:Result name="MassFlowRate">
-            <mtc:mLayer aspect="as_mass_flow_rate" id="AS134"></mtc:mLayer>
             <uom:Quantity name="flow-mass"></uom:Quantity>
+            <mtc:mLayer aspect="as_mass_flow_rate" id="AS134"></mtc:mLayer>
 	</mtc:Result>
 	<mtc:Parameter name="MassFlowRate" optional="false">
 	    <mtc:Definition>Mass of a substance passing through a specific cross-sectional area</mtc:Definition>
-            <mtc:mLayer aspect="as_mass_flow_rate" id="AS134"></mtc:mLayer>
             <uom:Quantity name="flow-mass"></uom:Quantity>
+            <mtc:mLayer aspect="as_mass_flow_rate" id="AS134"></mtc:mLayer>
 	</mtc:Parameter>
 	<mtc:Parameter name="Temperature" optional="true">
             <mtc:Definition>Temperature of the gas used during the measurement</mtc:Definition>
-            <mtc:mLayer aspect="as_thermodynamic_temperature" id="AS101"></mtc:mLayer>
             <uom:Quantity name="temperature"></uom:Quantity>
+            <mtc:mLayer aspect="as_thermodynamic_temperature" id="AS101"></mtc:mLayer>
 	</mtc:Parameter>
 	<mtc:Parameter name="Pressure" optional="true">
             <mtc:Definition>Pressure of the gas used during the measurement</mtc:Definition>
-            <mtc:mLayer aspect="as_pressure" id="AS14"></mtc:mLayer>
             <uom:Quantity name="pressure:differential"></uom:Quantity>
+            <mtc:mLayer aspect="as_pressure" id="AS14"></mtc:mLayer>
 	</mtc:Parameter>
 	<mtc:Parameter name="RelativeHumidity " optional="true">
             <mtc:Definition>Relative humidity (water content) of the gas used during measurement, mostly applicable to ambient air as the medium</mtc:Definition>
-            <mtc:mLayer aspect="as_relative_humidity" id="AS110"></mtc:mLayer>
             <uom:Quantity name="relative-humidity"></uom:Quantity>
+            <mtc:mLayer aspect="as_relative_humidity" id="AS110"></mtc:mLayer>
 	</mtc:Parameter>
 	<mtc:Parameter name="Compressibility" optional="true">
             <mtc:Definition>Relative volume change as a result of a pressure change of the gas used</mtc:Definition>
 	</mtc:Parameter>
 	<mtc:Parameter name="ReferenceTemperature" optional="true">
             <mtc:Definition> Reference temperature condition to or from which to correct the flow rate</mtc:Definition>
-            <mtc:mLayer aspect="as_thermodynamic_temperature" id="AS101"></mtc:mLayer>
             <uom:Quantity name="temperature"></uom:Quantity>
+            <mtc:mLayer aspect="as_thermodynamic_temperature" id="AS101"></mtc:mLayer>
 	</mtc:Parameter>
 	<mtc:Parameter name="ReferencePressure" optional="true">
             <mtc:Definition>Reference pressure condition to or from which to correct the flow rate</mtc:Definition>
-            <mtc:mLayer aspect="as_pressure" id="AS14"></mtc:mLayer>
             <uom:Quantity name="pressure:differential"></uom:Quantity>
+            <mtc:mLayer aspect="as_pressure" id="AS14"></mtc:mLayer>
 	</mtc:Parameter>
 	<mtc:Parameter name="ReferenceRelativeHumidity" optional="true">
             <mtc:Definition>Reference Relative Humidity: condition to or from which to correct the flow rate</mtc:Definition>
-            <mtc:mLayer aspect="as_relative_humidity" id="AS110"></mtc:mLayer>
             <uom:Quantity name="relative-humidity"></uom:Quantity>
+            <mtc:mLayer aspect="as_relative_humidity" id="AS110"></mtc:mLayer>
 	</mtc:Parameter>
 	<mtc:Parameter name="ReferenceCompressibility" optional="true">
 		<mtc:Definition>Relative volume change as a result of a pressure change for the reference gas</mtc:Definition>
 	</mtc:Parameter>
 	<mtc:Parameter name="AmbientTemperature" optional="true">
             <mtc:Definition></mtc:Definition>
-            <mtc:mLayer aspect="as_thermodynamic_temperature" id="AS101"></mtc:mLayer>
             <uom:Quantity name="temperature"></uom:Quantity>
+            <mtc:mLayer aspect="as_thermodynamic_temperature" id="AS101"></mtc:mLayer>
 	</mtc:Parameter>
 	<mtc:Parameter name="AmbientPressure" optional="true">
             <mtc:Definition></mtc:Definition>
-            <mtc:mLayer aspect="as_pressure" id="AS14"></mtc:mLayer>
             <uom:Quantity name="pressure:absolute"></uom:Quantity>
+            <mtc:mLayer aspect="as_pressure" id="AS14"></mtc:mLayer>
 	</mtc:Parameter>
 	<mtc:Parameter name="AmbientRelativeHumidity" optional="true">
             <mtc:Definition></mtc:Definition>
-            <mtc:mLayer aspect="as_relative_humidity" id="AS110"></mtc:mLayer>
             <uom:Quantity name="relative-humidity"></uom:Quantity>
+            <mtc:mLayer aspect="as_relative_humidity" id="AS110"></mtc:mLayer>
 	</mtc:Parameter>
 	<mtc:Parameter name="OutletPressure" optional="true">
             <mtc:Definition>Outlet pressure ambient or otherwise</mtc:Definition>
-            <mtc:mLayer aspect="as_pressure" id="AS14"></mtc:mLayer>
             <uom:Quantity name="pressure:differential"></uom:Quantity>
+            <mtc:mLayer aspect="as_pressure" id="AS14"></mtc:mLayer>
 	</mtc:Parameter>
 	<mtc:Parameter name="ReynoldsNumber" optional="true">
 		<mtc:Definition>Dimensionless quantity that characterizes the degree of laminar versus turbulent flow</mtc:Definition>
 	</mtc:Parameter>
 	<mtc:Parameter name="GasVelocity" optional="true">
             <mtc:Definition>speed of the gas through the measurement area</mtc:Definition>
-            <mtc:mLayer aspect="as_speed" id="AS38"></mtc:mLayer>
             <uom:Quantity name="speed"></uom:Quantity>
+            <mtc:mLayer aspect="as_speed" id="AS38"></mtc:mLayer>
 	</mtc:Parameter>
 	<mtc:Parameter name="GasSpecies" optional="true">
             <mtc:Definition>Species of source gas for flow calibrations</mtc:Definition>
@@ -94,13 +94,13 @@
 	</mtc:Parameter>
 	<mtc:Parameter name="InnerDiameter" optional="true">
             <mtc:Definition>Diameter of the pipe used in the measurement</mtc:Definition>
-            <mtc:mLayer aspect="as_length" id="AS3"></mtc:mLayer>
             <uom:Quantity name="length"></uom:Quantity>
+            <mtc:mLayer aspect="as_length" id="AS3"></mtc:mLayer>
 	</mtc:Parameter>
 	<mtc:Parameter name="DynamicViscosity" optional="true">
             <mtc:Definition>Fluid internal resistance to flow</mtc:Definition>
-            <mtc:mLayer aspect="as_dynamic_viscosity" id="AS107"></mtc:mLayer>
             <uom:Quantity name="dynamic-viscosity"></uom:Quantity>
+            <mtc:mLayer aspect="as_dynamic_viscosity" id="AS107"></mtc:mLayer>
         </mtc:Parameter>
 	<mtc:Discipline name=""></mtc:Discipline>
 	<mtc:Definition>This process sources a reference mass flow rate of gas for calibrating gas-flow meters. The instantaneous mass flow rate q_m equals dm/dt, sometimes estimated as ∆m/∆t using the total mass ∆m flowing through a defined surface in time ∆t.</mtc:Definition>

--- a/source/Source_MassFlowRate_Gas.xml
+++ b/source/Source_MassFlowRate_Gas.xml
@@ -1,69 +1,107 @@
 <?xml version="1.0" encoding="utf-8"?>
 <mtc:Taxon name="Source.MassFlowRate.Gas" deprecated="false" replacement="" xmlns:uom="https://cls-schemas.s3.us-west-1.amazonaws.com/MII/UOM_Database" xmlns:mtc="https://cls-schemas.s3.us-west-1.amazonaws.com/MII/MeasurandTaxonomyCatalog">
 	<mtc:Result name="MassFlowRate">
-		<mtc:mLayer aspect="as_mass_flow_rate" id="AS134"></mtc:mLayer>
+            <mtc:mLayer aspect="as_mass_flow_rate" id="AS134"></mtc:mLayer>
+            <uom:Quantity name="flow-mass"></uom:Quantity>
 	</mtc:Result>
 	<mtc:Parameter name="MassFlowRate" optional="false">
-		<mtc:Definition>Mass of a substance passing through a specific cross-sectional area</mtc:Definition>
-		<mtc:mLayer aspect="as_mass_flow_rate" id="AS134"></mtc:mLayer>
+	    <mtc:Definition>Mass of a substance passing through a specific cross-sectional area</mtc:Definition>
+            <mtc:mLayer aspect="as_mass_flow_rate" id="AS134"></mtc:mLayer>
+            <uom:Quantity name="flow-mass"></uom:Quantity>
 	</mtc:Parameter>
 	<mtc:Parameter name="Temperature" optional="true">
-		<mtc:Definition>Temperature of the gas used during the measurement</mtc:Definition>
-		<mtc:mLayer aspect="as_thermodynamic_temperature" id="AS101"></mtc:mLayer>
+            <mtc:Definition>Temperature of the gas used during the measurement</mtc:Definition>
+            <mtc:mLayer aspect="as_thermodynamic_temperature" id="AS101"></mtc:mLayer>
+            <uom:Quantity name="temperature"></uom:Quantity>
 	</mtc:Parameter>
 	<mtc:Parameter name="Pressure" optional="true">
-		<mtc:Definition>Pressure of the gas used during the measurement</mtc:Definition>
-		<mtc:mLayer aspect="as_pressure" id="AS14"></mtc:mLayer>
+            <mtc:Definition>Pressure of the gas used during the measurement</mtc:Definition>
+            <mtc:mLayer aspect="as_pressure" id="AS14"></mtc:mLayer>
+            <uom:Quantity name="pressure:differential"></uom:Quantity>
 	</mtc:Parameter>
 	<mtc:Parameter name="RelativeHumidity " optional="true">
-		<mtc:Definition>Relative humidity (water content) of the gas used during measurement, mostly applicable to ambient air as the medium</mtc:Definition>
-		<mtc:mLayer aspect="as_relative_humidity" id="AS110"></mtc:mLayer>
+            <mtc:Definition>Relative humidity (water content) of the gas used during measurement, mostly applicable to ambient air as the medium</mtc:Definition>
+            <mtc:mLayer aspect="as_relative_humidity" id="AS110"></mtc:mLayer>
+            <uom:Quantity name="relative-humidity"></uom:Quantity>
 	</mtc:Parameter>
 	<mtc:Parameter name="Compressibility" optional="true">
-		<mtc:Definition>Relative volume change as a result of a pressure change of the gas used</mtc:Definition>
+            <mtc:Definition>Relative volume change as a result of a pressure change of the gas used</mtc:Definition>
 	</mtc:Parameter>
 	<mtc:Parameter name="ReferenceTemperature" optional="true">
-		<mtc:Definition> Reference temperature condition to or from which to correct the flow rate</mtc:Definition>
-		<mtc:mLayer aspect="as_thermodynamic_temperature" id="AS101"></mtc:mLayer>
+            <mtc:Definition> Reference temperature condition to or from which to correct the flow rate</mtc:Definition>
+            <mtc:mLayer aspect="as_thermodynamic_temperature" id="AS101"></mtc:mLayer>
+            <uom:Quantity name="temperature"></uom:Quantity>
 	</mtc:Parameter>
 	<mtc:Parameter name="ReferencePressure" optional="true">
-		<mtc:Definition>Reference pressure condition to or from which to correct the flow rate</mtc:Definition>
-		<mtc:mLayer aspect="as_pressure" id="AS14"></mtc:mLayer>
+            <mtc:Definition>Reference pressure condition to or from which to correct the flow rate</mtc:Definition>
+            <mtc:mLayer aspect="as_pressure" id="AS14"></mtc:mLayer>
+            <uom:Quantity name="pressure:differential"></uom:Quantity>
 	</mtc:Parameter>
 	<mtc:Parameter name="ReferenceRelativeHumidity" optional="true">
-		<mtc:Definition>Reference Relative Humidity: condition to or from which to correct the flow rate</mtc:Definition>
-		<mtc:mLayer aspect="as_relative_humidity" id="AS110"></mtc:mLayer>
+            <mtc:Definition>Reference Relative Humidity: condition to or from which to correct the flow rate</mtc:Definition>
+            <mtc:mLayer aspect="as_relative_humidity" id="AS110"></mtc:mLayer>
+            <uom:Quantity name="relative-humidity"></uom:Quantity>
 	</mtc:Parameter>
 	<mtc:Parameter name="ReferenceCompressibility" optional="true">
 		<mtc:Definition>Relative volume change as a result of a pressure change for the reference gas</mtc:Definition>
 	</mtc:Parameter>
 	<mtc:Parameter name="AmbientTemperature" optional="true">
-		<mtc:Definition></mtc:Definition>
-		<mtc:mLayer aspect="as_thermodynamic_temperature" id="AS101"></mtc:mLayer>
+            <mtc:Definition></mtc:Definition>
+            <mtc:mLayer aspect="as_thermodynamic_temperature" id="AS101"></mtc:mLayer>
+            <uom:Quantity name="temperature"></uom:Quantity>
 	</mtc:Parameter>
 	<mtc:Parameter name="AmbientPressure" optional="true">
-		<mtc:Definition></mtc:Definition>
-		<mtc:mLayer aspect="as_pressure" id="AS14"></mtc:mLayer>
+            <mtc:Definition></mtc:Definition>
+            <mtc:mLayer aspect="as_pressure" id="AS14"></mtc:mLayer>
+            <uom:Quantity name="pressure:absolute"></uom:Quantity>
 	</mtc:Parameter>
 	<mtc:Parameter name="AmbientRelativeHumidity" optional="true">
-		<mtc:Definition></mtc:Definition>
-		<mtc:mLayer aspect="as_relative_humidity" id="AS110"></mtc:mLayer>
+            <mtc:Definition></mtc:Definition>
+            <mtc:mLayer aspect="as_relative_humidity" id="AS110"></mtc:mLayer>
+            <uom:Quantity name="relative-humidity"></uom:Quantity>
 	</mtc:Parameter>
 	<mtc:Parameter name="OutletPressure" optional="true">
-		<mtc:Definition>Outlet pressure ambient or otherwise</mtc:Definition>
-		<mtc:mLayer aspect="as_pressure" id="AS14"></mtc:mLayer>
+            <mtc:Definition>Outlet pressure ambient or otherwise</mtc:Definition>
+            <mtc:mLayer aspect="as_pressure" id="AS14"></mtc:mLayer>
+            <uom:Quantity name="pressure:differential"></uom:Quantity>
 	</mtc:Parameter>
 	<mtc:Parameter name="ReynoldsNumber" optional="true">
 		<mtc:Definition>Dimensionless quantity that characterizes the degree of laminar versus turbulent flow</mtc:Definition>
 	</mtc:Parameter>
 	<mtc:Parameter name="GasVelocity" optional="true">
-		<mtc:Definition>speed of the gas through the measurement area</mtc:Definition>
-		<mtc:mLayer aspect="as_speed" id="AS38"></mtc:mLayer>
+            <mtc:Definition>speed of the gas through the measurement area</mtc:Definition>
+            <mtc:mLayer aspect="as_speed" id="AS38"></mtc:mLayer>
+            <uom:Quantity name="speed"></uom:Quantity>
 	</mtc:Parameter>
-	<mtc:Parameter name="Diameter" optional="true">
-		<mtc:Definition>Diameter of the pipe used in the measurement</mtc:Definition>
-		<mtc:mLayer aspect="as_length" id="AS3"></mtc:mLayer>
+	<mtc:Parameter name="GasSpecies" optional="true">
+            <mtc:Definition>Species of source gas for flow calibrations</mtc:Definition>
+            <mtc:Property name="GasSpecies" id="propertyIDx9r4">
+                <mtc:Definition>Identifiers for elements, compounds, mixtures for flow calibrations</mtc:Definition> 
+                <mtc:NominalValues>Air He Ar N2 CO2 CH4 C3H8 C4H10 H2S CO H2 Cl2</mtc:NominalValues>
+                <mtc:ExternalReferences>
+                    <mtc:Reference>
+                        <mtc:CategoryTag> 
+                            <mtc:name>"CAS Registry"</mtc:name>
+                            <mtc:value>"CAS Common Chemistry"</mtc:value>
+                        </mtc:CategoryTag>
+                        <mtc:ReferenceUrl> 
+                            <mtc:name>"CAS Common Chemistry"</mtc:name> 
+                            <mtc:url>"https://commonchemistry.cas.org/"</mtc:url>
+                        </mtc:ReferenceUrl>
+                    </mtc:Reference>
+                </mtc:ExternalReferences>
+            </mtc:Property>
 	</mtc:Parameter>
+	<mtc:Parameter name="InnerDiameter" optional="true">
+            <mtc:Definition>Diameter of the pipe used in the measurement</mtc:Definition>
+            <mtc:mLayer aspect="as_length" id="AS3"></mtc:mLayer>
+            <uom:Quantity name="length"></uom:Quantity>
+	</mtc:Parameter>
+	<mtc:Parameter name="DynamicViscosity" optional="true">
+            <mtc:Definition>Fluid internal resistance to flow</mtc:Definition>
+            <mtc:mLayer aspect="as_dynamic_viscosity" id="AS107"></mtc:mLayer>
+            <uom:Quantity name="dynamic-viscosity"></uom:Quantity>
+        </mtc:Parameter>
 	<mtc:Discipline name=""></mtc:Discipline>
 	<mtc:Definition>This process sources a reference mass flow rate of gas for calibrating gas-flow meters. The instantaneous mass flow rate q_m equals dm/dt, sometimes estimated as ∆m/∆t using the total mass ∆m flowing through a defined surface in time ∆t.</mtc:Definition>
 </mtc:Taxon>


### PR DESCRIPTION
This PR adds a source mass flow rate taxon that will be used in subsequent flow taxons to complete the gas flow for mass and volume taxonomy. 
- Merges latest changes from main with schema update for Properties.
- Uses the GasSpecies property as a parameter.
- Specifies Source MassFlowRate for Gas